### PR TITLE
Add api_level=21 to android_ndk_repository

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -62,4 +62,4 @@ apple_support_dependencies()
 
 android_sdk_repository(name = "androidsdk")
 
-android_ndk_repository(name = "androidndk")
+android_ndk_repository(name = "androidndk", api_level=21)


### PR DESCRIPTION
Without this parameter, the NDK rule will assume we're using an old version of NDK and the `platforms` directory should exist:

```shell
$ bazel build ios_app                                           
ERROR: /Volumes/SharedVol/bazel-related/bazel-rust-mobile-demo/WORKSPACE:65:23: fetching android_ndk_repository rule //external:androidndk: java.io.IOException: Expected directory at /opt/homebrew/share/android-ndk/platforms but it is not a directory or it does not exist. Unable to read the Android NDK at /opt/homebrew/share/android-ndk, the path may be invalid. Is the path in android_ndk_repository() or ANDROID_NDK_HOME set correctly? If the path is correct, the contents in the Android NDK directory may have been modified.
ERROR: Analysis of target '//:ios_app' failed; build aborted: Expected directory at /opt/homebrew/share/android-ndk/platforms but it is not a directory or it does not exist. Unable to read the Android NDK at /opt/homebrew/share/android-ndk, the path may be invalid. Is the path in android_ndk_repository() or ANDROID_NDK_HOME set correctly? If the path is correct, the contents in the Android NDK directory may have been modified.
INFO: Elapsed time: 4.421s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (41 packages loaded, 58 targets configured)
    currently loading: @rust_darwin_aarch64_toolchains// ... (14 packages)
    Fetching @local_config_cc_toolchains; Building xcode-locator
    Fetching @androidsdk; Restarting.
    Fetching @local_jdk; fetching
```

Reference: https://github.com/google/mediapipe/issues/1281#issuecomment-786498715