### PR TITLE
rules_java #64 repro case

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -94,8 +94,8 @@ platform(
 platform(
     name = "android_armeabi",
     constraint_values = [
-        "@platforms//cpu:arm",  # This will soon change to armv7 https://github.com/bazelbuild/bazel/issues/14982
-        # "@platforms//cpu:armv7",  # Use this instead of :arm if you're on bazel 6.x
+        # "@platforms//cpu:arm",  # This will soon change to armv7 https://github.com/bazelbuild/bazel/issues/14982
+        "@platforms//cpu:armv7",  # Use this instead of :arm if you're on bazel 6.x
         "@platforms//os:android",
     ],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,8 +1,20 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
+    name = "rules_java",
+    sha256 = "a7379f127256d21c966edee89e00498e2994e98da3c10a62d8bc90e148a16534",
+    strip_prefix = "rules_java-6e03a930850249d4c982d236fbed6091bf283c4e",
+    url = "https://github.com/bazelbuild/rules_java/archive/6e03a930850249d4c982d236fbed6091bf283c4e.tar.gz",
+)
+
+load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_java_toolchains")
+
+rules_java_dependencies()
+
+rules_java_toolchains()
+
+http_archive(
     name = "rules_rust",
-    patches = ["//:rules_rust.patch"],  # Remove if you're using bazel 6.x
     sha256 = "edb87c0d2ba70823fe3df7862676d695599314a4634b9758bd55f0e8f19c2751",
     urls = [
         "https://mirror.bazel.build/github.com/bazelbuild/rules_rust/releases/download/0.4.0/rules_rust-v0.4.0.tar.gz",
@@ -62,4 +74,7 @@ apple_support_dependencies()
 
 android_sdk_repository(name = "androidsdk")
 
-android_ndk_repository(name = "androidndk", api_level=21)
+android_ndk_repository(
+    name = "androidndk",
+    api_level = 21,
+)


### PR DESCRIPTION
Building with:

```
USE_BAZEL_VERSION=last_green bazelisk build android_app --java_runtime_version=remotejdk_11
```

reproduces https://github.com/bazelbuild/rules_java/issues/64

Removing the `--java_runtime_version` argument does not reproduce it